### PR TITLE
Add info for Tiny Wii Backup Manager

### DIFF
--- a/src/routes/Populars/about-rvz-files/+page.svelte
+++ b/src/routes/Populars/about-rvz-files/+page.svelte
@@ -15,6 +15,10 @@
         RVZ files work with the Dolphin emulator but not on real hardware. They
         also help save bandwidth for both you and the website hosting the files
         when downloading. If you are using real hardware, use <a
+            href="https://github.com/mq1/TinyWiiBackupManager"
+            class="text-primary font-medium underline underline-offset-4 md:text-base hover:bg-primary hover:text-primary-foreground"
+            >Tiny Wii Backup Manager</a
+        > to automatically convert to WBFS or ISO when transferring to the external drive, or use <a
             href="https://dolphin-emu.org/"
             class="text-primary font-medium underline underline-offset-4 md:text-base hover:bg-primary hover:text-primary-foreground"
             >Dolphin Emulator</a


### PR DESCRIPTION
I want to add information for Tiny Wii Backup Manager, as a new method for converting RVZ to WBFS/ISO for real hardware users, and as a new backup manager tool and new replacement for Wii Backup Manager (Windows) and Wii Backup Fusion (Windows, macOS, Linux)